### PR TITLE
Remove dependencies of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
 Django==1.8
-django-appconf==1.0.1
 django-compressor==1.4
 django-libsass==0.2
-libsass==0.7.0
-six==1.9.0
 django-bower==5.0.4
-


### PR DESCRIPTION
It's usually a good idea to only keep track of the packages/versions that you intend to use. That way if there's updates to the dependencies, they aren't locked down when you didn't even install that version yourself anyways. It's also more clear for projects like this which packages are being used directly.
