### PR TITLE
Bootstrap 3.3.1 -> 3.3.6 + Bad Bootstrap Path

### DIFF
--- a/example/settings.py
+++ b/example/settings.py
@@ -45,7 +45,7 @@ INSTALLED_APPS = (
 )
 
 BOWER_INSTALLED_APPS = (
-    'bootstrap-sass-official#3.3.1',
+    'bootstrap-sass-official#3.3.6',
 )
 
 BOWER_COMPONENTS_ROOT = os.path.join(BASE_DIR, 'components')

--- a/sample_app/static/sass/app.scss
+++ b/sample_app/static/sass/app.scss
@@ -1,5 +1,5 @@
 $icon-font-path: "../bootstrap-sass-official/assets/fonts/bootstrap/";
-@import "bootstrap-sass-official/assets/stylesheets/bootstrap";
+@import "bootstrap-sass/assets/stylesheets/bootstrap";
 
 .container {
   .lead {


### PR DESCRIPTION
Bower now installs bootstrap to /components/bootstrap-ssass instead of /components/bootstrap-sass-official. Static .scss needed to be updated.
