### PR TITLE
remove COMPRESS_ENABLED from settings.py

### DIFF
--- a/example/settings.py
+++ b/example/settings.py
@@ -125,7 +125,6 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 # django-compressor
 
-COMPRESS_ENABLED = True
 COMPRESS_URL = STATIC_URL
 
 COMPRESS_PRECOMPILERS = (


### PR DESCRIPTION
[django-compressor manages this switch](http://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_ENABLED) to be the opposite of `DEBUG`. There's no need to set it unless compression is desired in development, which for me, was confusing. When compression is enabled, using `@import`s in scss do not get refreshed/recompiled with each new request. I had to restart my server every time I made a change to one of those imported files.
By removing this, compression will still happen when `DEBUG = False`, which is the only time it should, in my opinion.
